### PR TITLE
Add neorv32-setups through submodules

### DIFF
--- a/.github/workflows/Implementation.yml
+++ b/.github/workflows/Implementation.yml
@@ -17,6 +17,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -37,6 +40,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -57,6 +63,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -77,6 +86,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -97,6 +109,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -117,6 +132,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -137,6 +155,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -157,6 +178,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -177,6 +201,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -197,6 +224,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -217,6 +247,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -237,6 +270,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -257,6 +293,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -277,6 +316,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -297,6 +339,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -317,6 +362,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -337,6 +385,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:
@@ -357,6 +408,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - uses: docker://ghcr.io/unike267/containers/impl-arty:latest
         with:

--- a/.github/workflows/Simulation.yml
+++ b/.github/workflows/Simulation.yml
@@ -41,6 +41,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run slink Complex Latency test'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -63,6 +66,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run slink Complex Throughput test'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -98,6 +104,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run wishbone Complex Latency test'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -120,6 +129,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run wishbone Complex Throughput test'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -143,6 +155,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run CFU Complex Latency test for mult_wfifos'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -164,6 +179,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run CFU Complex Latency test for multp_wfifos'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -185,6 +203,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run CFU Complex Latency test for multp'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -206,6 +227,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run CFS Complex Latency test for buffering multipliers'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -229,6 +253,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run CFS Complex Latency test for not buffering multipliers'
         uses: docker://docker.io/ghdl/vunit:mcode-master
@@ -248,6 +275,9 @@ jobs:
 
       - name: '🧰 Checkout'
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 'Run CFS Complex Throughput test for buffering multipliers'
         uses: docker://docker.io/ghdl/vunit:mcode-master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "neorv32-setups"]
+	path = neorv32-setups
+	url = git@github.com:stnolting/neorv32-setups

--- a/impl/nextpnr/impl_mult_wfifos_cfs.sh
+++ b/impl/nextpnr/impl_mult_wfifos_cfs.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/CFS/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 mv rtl/mult/CFS/neorv32_cfs.vhd neorv32-setups/neorv32/rtl/core

--- a/impl/nextpnr/impl_mult_wfifos_slink.sh
+++ b/impl/nextpnr/impl_mult_wfifos_slink.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/slink/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/impl/nextpnr/impl_mult_wfifos_wishbone.sh
+++ b/impl/nextpnr/impl_mult_wfifos_wishbone.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/EMEM/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/impl/nextpnr/impl_multp_cfs.sh
+++ b/impl/nextpnr/impl_multp_cfs.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/multp/CFS/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 mv rtl/multp/CFS/neorv32_cfs.vhd neorv32-setups/neorv32/rtl/core

--- a/impl/nextpnr/impl_multp_slink.sh
+++ b/impl/nextpnr/impl_multp_slink.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/slink/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/impl/nextpnr/impl_multp_wfifos_cfs.sh
+++ b/impl/nextpnr/impl_multp_wfifos_cfs.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/CFS/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 mv rtl/mult/CFS/neorv32_cfs.vhd neorv32-setups/neorv32/rtl/core

--- a/impl/nextpnr/impl_multp_wfifos_slink.sh
+++ b/impl/nextpnr/impl_multp_wfifos_slink.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/slink/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/impl/nextpnr/impl_multp_wfifos_wishbone.sh
+++ b/impl/nextpnr/impl_multp_wfifos_wishbone.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/EMEM/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/impl/nextpnr/impl_mults_cfu.sh
+++ b/impl/nextpnr/impl_mults_cfu.sh
@@ -16,13 +16,7 @@ else
 fi
 echo "Selected board is" $Arty
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/CFU/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 mv rtl/mult/CFU/neorv32_cpu_cp_cfu.vhd neorv32-setups/neorv32/rtl/core

--- a/sim/test/test_CFS_Complex_Latency.sh
+++ b/sim/test/test_CFS_Complex_Latency.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 if [[ -z "${Fifos}" ]]; then
     echo "Start test"

--- a/sim/test/test_CFS_Complex_Throughput.sh
+++ b/sim/test/test_CFS_Complex_Throughput.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/CFS/sim/THROUGHPUT/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 mv rtl/mult/CFS/neorv32_cfs.vhd neorv32-setups/neorv32/rtl/core

--- a/sim/test/test_CFU_Complex_Latency.sh
+++ b/sim/test/test_CFU_Complex_Latency.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 if [[ -z "${Design}" ]]; then
     mv rtl/mult/CFU/SIM/LATENCY/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core

--- a/sim/test/test_slink_Complex_Latency.sh
+++ b/sim/test/test_slink_Complex_Latency.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/slink/sim/LATENCY/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/sim/test/test_slink_Complex_Throughput.sh
+++ b/sim/test/test_slink_Complex_Throughput.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/slink/sim/THROUGHPUT/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/sim/test/test_wishbone_Complex_Latency.sh
+++ b/sim/test/test_wishbone_Complex_Latency.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/EMEM/sim/LATENCY/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 

--- a/sim/test/test_wishbone_Complex_Throughput.sh
+++ b/sim/test/test_wishbone_Complex_Throughput.sh
@@ -4,13 +4,7 @@ set -ex
 
 cd $(dirname "$0")
 
-apt update -qq
-
-apt install -y git
-
 cd ../..
-
-git clone --recursive https://github.com/stnolting/neorv32-setups
 
 mv rtl/mult/EMEM/sim/THROUGHPUT/neorv32_application_image.vhd neorv32-setups/neorv32/rtl/core
 


### PR DESCRIPTION
Instead of cloning the neorv32-setups repository in the script executed in CI use the neorv32-setups submodule directly. 

To work according to the project code:

Bump neorv32-setups to:
`a9b61ded34987af30e4a7b9e15d4feb71151b004`

At the same time it is necessary to bump the neorv32 module to the corresponding commit, in this case:
`1da82dc370353871e0c30476d5ec94ada360b0e8`